### PR TITLE
fixing bug in make file where it would nest directories in themselves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: $(GENERIC) commands
 .PHONY: $(GENERIC)
 $(GENERIC):
 	mkdir -p $(DEST)
-	cp -R "$(REDIS_DOC)/$@" "$(DEST)/$@"
+	cp -R "$(REDIS_DOC)/$@" "$(DEST)"
 
 commands:
 	cp -R "$(REDIS_DOC)/$@" "$(DEST)/"


### PR DESCRIPTION
Fixed a little bug in the make file, without this fix the `docs` folder was being copied into the `conent/en/docs` folder if it already existed and making some weird nested stuff.